### PR TITLE
fix: add exact version to pinned action comments in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,16 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
           cache: npm
 
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Install dependencies
         run: npm ci
@@ -37,7 +37,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./dist
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

- ハッシュピンされた GitHub Actions のコメントをメジャーバージョンのみ（例: `# v6`）から正確なバージョン（例: `# v6.0.2`）に修正

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `# v6` | `# v6.0.2` |
| `actions/setup-node` | `# v6` | `# v6.2.0` |
| `actions/configure-pages` | `# v5` | `# v5.0.0` |
| `actions/upload-pages-artifact` | `# v4` | `# v4.0.0` |
| `actions/deploy-pages` | `# v4` | `# v4.0.5` |

Closes #12 と重複するため、このPRとは別に #12 のクローズを検討してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)